### PR TITLE
Add a daily cron job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - dev
+  schedule:
+    - cron: '00 00 * * *'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
In #32, we added an automatically-generated list of public Julia package repositories in the JuliaHealth organization.

In order to keep this list up-to-date, we need to a daily cron job that builds and deploys the documentation. This will ensure that the list of Julia packages stays up-to-date.

This PR adds the daily cron job.