### PR TITLE
Change "Last modified" to "Last updated"

### DIFF
--- a/_layout/page_foot.html
+++ b/_layout/page_foot.html
@@ -1,5 +1,5 @@
 <div class="page-foot">
   <div class="copyright">
-    &copy; {{ fill author }}. Last modified: {{ fill fd_mtime }}. <a id="github" href="https://github.com/JuliaHealth/juliahealth.github.io/blob/dev/{{fd_rpath}}">Edit this page on GitHub</a>. Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a>. Powered by <a href="https://julialang.org">Julia programming language</a>.
+    &copy; {{ fill author }}. Last updated: {{ fill fd_mtime }}. <a id="github" href="https://github.com/JuliaHealth/juliahealth.github.io/blob/dev/{{fd_rpath}}">Edit this page on GitHub</a>. Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a>. Powered by <a href="https://julialang.org">Julia programming language</a>.
   </div>
 </div>


### PR DESCRIPTION
We have a daily cron job. This ensures that our list of packages is kept up-to-date.

However, because the website is automatically build daily, it doesn't make sense to have a "last modified" date. It should probably say "last updated" instead.